### PR TITLE
Add compatibility with GHC 8.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ env:
   - STACK_YAML=ghc-822.yaml
   - STACK_YAML=ghc-841.yaml
 
-matrix:
-  allow_failures:
-    - env: STACK_YAML=ghc-841.yaml
-
 # Caching so the next build will be fast too.
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - STACK_YAML=stack.yaml
   - STACK_YAML=ghc-802.yaml
   - STACK_YAML=ghc-822.yaml
+  - STACK_YAML=ghc-841.yaml
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ env:
   - STACK_YAML=ghc-822.yaml
   - STACK_YAML=ghc-841.yaml
 
+matrix:
+  allow_failures:
+    - env: STACK_YAML=ghc-841.yaml
+
 # Caching so the next build will be fast too.
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Additional builds with GHC 8.0.2 and 8.2.1
+* Compatibility with GHC 8.4.1
 
 ## 3.0.0
 

--- a/dom-parser.cabal
+++ b/dom-parser.cabal
@@ -12,6 +12,7 @@ homepage:            https://github.com/typeable/dom-parser
 tested-with:         GHC == 7.10.3
                    , GHC == 8.0.2
                    , GHC == 8.2.2
+                   , GHC == 8.4.1
 extra-source-files:  CHANGELOG.md
                    , README.md
 

--- a/ghc-841.yaml
+++ b/ghc-841.yaml
@@ -1,0 +1,1 @@
+resolver: nightly-2018-03-15

--- a/ghc-841.yaml
+++ b/ghc-841.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2018-03-15
+resolver: nightly-2018-03-16

--- a/src/Text/XML/DOM/Parser/Types.hs
+++ b/src/Text/XML/DOM/Parser/Types.hs
@@ -36,6 +36,7 @@ import Control.Lens
 import Control.Monad.Except
 import Control.Monad.Reader
 import Data.CaseInsensitive as CI
+import Data.Semigroup
 import Data.String
 import Data.Text as T
 import GHC.Generics (Generic)
@@ -134,7 +135,7 @@ matchName n = NameMatcher
 -- element of the document. Errors are much more usefull with path.
 newtype DomPath = DomPath
   { unDomPath :: [Text]
-  } deriving (Eq, Ord, Show, Monoid)
+  } deriving (Eq, Ord, Show, Semigroup, Monoid)
 
 -- | DOM parser error description.
 data ParserError
@@ -184,7 +185,7 @@ instance Exception ParserError
 
 newtype ParserErrors = ParserErrors
   { unParserErrors :: [ParserError]
-  } deriving (Show, Monoid, Generic)
+  } deriving (Show, Semigroup, Monoid, Generic)
 
 makePrisms ''ParserErrors
 


### PR DESCRIPTION
Close #10 

Since [`Semigroup` became a superclass of `Monoid`](https://ghc.haskell.org/trac/ghc/wiki/Migration/8.4#SemigroupMonoidsuperclasses) we need to derive `Semigroup` instance as well.

`Semigroup` import is redundant in case of `ghc-8.4.1`, but we need it for backward compatibility.

